### PR TITLE
Fix : Correct footer links in contact.html

### DIFF
--- a/src/contact.html
+++ b/src/contact.html
@@ -256,9 +256,9 @@
           <div class="col-md-6 ">
             <div class="footer-left d-flex justify-content-center align-items-center">
                 <div class="footer-links">
-                  <a href="index.html"><i class="fa-solid fa-house-crack"></i> Back to Home</a>
-                  <a href="index.html#services"><i class="fa-solid fa-hand-holding-heart"></i> Services</a>
-                  <a href="index.html#about"><i class="fa-solid fa-people-roof"></i> About Us</a>
+                   <a href="../index.html"><i class="fa-solid fa-house-crack"></i> Back to Home</a>
+                  <a href="../index.html#services"><i class="fa-solid fa-hand-holding-heart"></i> Services</a>
+                  <a href="../index.html#about"><i class="fa-solid fa-people-roof"></i> About Us</a>
                 </div>
             </div>
           </div>


### PR DESCRIPTION
On `/src/contact.html`, the footer navigation links ("Back to Home", "Services", "About Us") were using paths relative to `/src/`, which caused 404 errors.

**Fix:**
- Updated links to use `../index.html` so they point correctly to the root homepage and sections.

**Testing:**
Verified locally that clicking each footer link navigates to the correct page/section without errors.