### PR TITLE
[Fix] Footer Year Auto-Update & Social Links Open in New Tab (#300)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1305,19 +1305,19 @@
           <div class="social-section">
             <h6 class="social-title">Follow Us</h6>
             <div class="social-links">
-              <a href="https://facebook.com" class="social-link" aria-label="Facebook">
+              <a target="_blank" href="https://facebook.com" class="social-link" aria-label="Facebook">
                 <i class="fab fa-facebook-f"></i>
               </a>
-              <a href="https://instagram.com" class="social-link" aria-label="Instagram">
+              <a target="_blank" href="https://instagram.com" class="social-link" aria-label="Instagram">
                 <i class="fab fa-instagram"></i>
               </a>
-              <a href="https://linkedin.com" class="social-link" aria-label="LinkedIn">
+              <a target="_blank" href="https://linkedin.com" class="social-link" aria-label="LinkedIn">
                 <i class="fab fa-linkedin-in"></i>
               </a>
-              <a href="https://github.com" class="social-link" aria-label="GitHub">
+              <a target="_blank" href="https://github.com" class="social-link" aria-label="GitHub">
                 <i class="fab fa-github"></i>
               </a>
-              <a href="https://twitter.com" class="social-link" aria-label="Twitter">
+              <a target="_blank" href="https://twitter.com" class="social-link" aria-label="Twitter">
                 <i class="fab fa-twitter"></i>
               </a>
 
@@ -1333,7 +1333,7 @@
         <div class="container">
           <div class="row align-items-center py-3">
             <div class="col-md-6">
-              <p class="copyright mb-0">© 2024
+              <p class="copyright mb-0">© <span id="currentYear"></span>
                 <strong>GrowCraft</strong>. All rights reserved.
               </p>
             </div>
@@ -1402,6 +1402,13 @@
     });
 
   </script>
+  <script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const yearSpan = document.getElementById("currentYear");
+    yearSpan.textContent = new Date().getFullYear();
+  });
+  </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
## Description
This PR fixes the hardcoded footer year and ensures social media links open in a new tab.

## Related Issue
Closes  #300

## Changes Made
- Replaced hardcoded footer year (`© 2024`) with a dynamic JavaScript solution that auto-updates each year.
- Updated all social media links in the footer to open in a new tab (`target="_blank"`)
- Verified styling and layout remain unaffected.

## Steps to Test
1. Open the site locally.
2. Scroll to the footer → confirm year matches the current year.
3. Click on social media icons → verify they open in a new tab.

## Screenshots (if applicable)
<img width="1897" height="389" alt="image" src="https://github.com/user-attachments/assets/e703fedb-503a-4c0d-85b5-cadfe91ed4e4" />


## Checklist
- [x] Code follows project guidelines
- [x] Tested locally on Chrome/Edge/Firefox
- [x] No console errors
- [x] Linked issue closed with PR
