### PR TITLE
Replaced Twitter logo with X logo #316

### DIFF
--- a/index.html
+++ b/index.html
@@ -1319,8 +1319,16 @@
               <a target="_blank" href="https://github.com" class="social-link" aria-label="GitHub">
                 <i class="fab fa-github"></i>
               </a>
-              <a target="_blank" href="https://twitter.com" class="social-link" aria-label="Twitter">
-                <i class="fab fa-twitter"></i>
+              <a target="_blank" href="https://twitter.com" class="social-link" aria-label="X">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" 
+                  viewBox="0 0 1200 1227">
+                  <path d="M714.163 545.37L1160.89 0H1055.53L667.137 
+                          460.42L362.14 0H0l468.615 682.215L0 1226.5h105.365l405.97
+                          -477.59l324.27 477.59h361.365L714.163 545.37zM552.885 
+                          689.17l-47.062-67.926L144.59 79.85h164.51l264.36 
+                          382.63l47.062 67.926l377.302 545.1H833.31L552.885 
+                          689.17z"/>
+              </svg>
               </a>
 
             </div>


### PR DESCRIPTION


fixes #316 

updated the tweet bird with X logo

<img width="1897" height="518" alt="image" src="https://github.com/user-attachments/assets/f9db7dcf-c353-4eca-b0b4-a89afe679d67" />
