### PR TITLE
Fix Underline Issue in Training & Internship Program Section

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -51,14 +51,16 @@ section {
   height: 40px;
   margin-bottom: 12px;
 }
+
 .program-card h6 {
-  font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;
-  transition: all 0.3s ease;
-  color: var(--green);
-  font-size: 1.4rem;
-  margin: 0;
-  font-weight: 400;
-  white-space: nowrap;
+    font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;
+    transition: all 0.3s ease;
+    color: var(--green);
+    font-size: 1.4rem;
+    margin: 0;
+    font-weight: 400;
+    white-space: nowrap;
+    text-decoration: none;
 }
 
 .program-card:hover {


### PR DESCRIPTION
## 📝 Description
Removed unnecessary underlines from the service titles (e.g., Website Development, Digital Marketing, etc.) in the Training and Internship Program section.
This improves visual consistency, ensures titles don’t appear as links, and aligns the design with the rest of the website. refer to issue #330 

## 🔧 Changes Made
Removed default underline styling from service card titles.
Ensured titles now follow the same clean, consistent typography as the rest of the UI.

## ✅ Expected Outcome
Service titles are now displayed without underlines.
Improved UI/UX consistency across the services section.
---
<img width="1920" height="1008" alt="Screenshot 2025-08-27 182925" src="https://github.com/user-attachments/assets/c373cc84-d47b-4d5c-bd40-7b2ee59672c9" />
