### PR TITLE
Fixed Previous & Next  buttons in the Slide bar section

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -242,7 +242,8 @@ h5 {
   background-color: transparent !important;
 }
 .icon {
-  height: 1.5rem;
+  height: 6.5rem;
+
 }
 
 .training-links {
@@ -308,7 +309,10 @@ h5 {
 }
 
 .nav-btn {
+  position:relative;
+  top:90%;
   filter: invert(1); 
+
 }
 
 .heading-text {
@@ -438,6 +442,11 @@ body.dark .progressive-load:not(.loaded) {
 
 /* Responsive adjustments for 2x2 layout */
 @media (max-width: 768px) {
+
+  .nav-btn{
+    top:230%;
+  }
+
   .card-services {
     margin: 0.5rem;
     padding: 1rem;
@@ -952,6 +961,7 @@ body.dark .copyright {
 
 body.dark .icon {
   filter: invert(1);
+
 }
 
 body.dark .mb-0:hover {


### PR DESCRIPTION
I have fixed the position of the previous and next buttons in the slideshow section .

<img width="1333" height="681" alt="Screenshot 2025-08-30 174202" src="https://github.com/user-attachments/assets/631862a4-ee2a-4826-868b-fb4b549a62b3" />

@gyanshankar1708 please check and merge this PR with label .

This was the #356 issue. Now has been resolved.

Thanks!