### PR TITLE
Fixed :Enhancement of styling of 'Stop Breaches Before They Start' heading under Cyber Analyst page

### DIFF
--- a/src/cyber-analyst.html
+++ b/src/cyber-analyst.html
@@ -199,7 +199,9 @@
   }
 
   .gc-gradient {
-    background: linear-gradient(90deg, var(--gc-primary-1), var(--gc-primary-2));
+background: linear-gradient(90deg, #6ea8fe, #a991f7, #d2a8ff);
+
+
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;


### PR DESCRIPTION
## Description:
This PR enhances the visual styling of the heading "Stop Breaches Before They Start" under the Cyber Analyst page.

## Related Issue:
Fixes : #379
## Change includes:

- Added a background gradient

## Why this change?

- Improves the visual hierarchy and emphasis on a key message

- Aligns with updated UI/UX design language across the platform


## BEFORE
<img width="1592" height="675" alt="image" src="https://github.com/user-attachments/assets/5f7b0754-b3ab-46c4-9b87-9c3a79a7b185" />


## AFTER
<img width="1453" height="622" alt="image" src="https://github.com/user-attachments/assets/87570592-2317-40c4-816a-f73133a12b28" />

Please merge this Pull Request @gyanshankar1708 