### PR TITLE
Fixed :Enhancement of gradient under 'Graphic Design' page

### DIFF
--- a/src/graphic_design.html
+++ b/src/graphic_design.html
@@ -636,12 +636,15 @@
 
     .btn-primary {
       background: var(--white);
-      color: var(--secondary);
-      box-shadow: 0 6px 15px rgba(0, 0, 0, 0.2);
+      color: black;
+      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+      border-radius: 8px; 
+      padding: 0.75rem 1.5rem;
     }
 
     .btn-primary:hover {
       background: #f1f1f1;
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
       transform: translateY(-3px) scale(1.05);
     }
 

--- a/src/graphic_design.html
+++ b/src/graphic_design.html
@@ -550,7 +550,13 @@
 
     .cta-section {
       position: relative;
-      background: linear-gradient(rgba(90, 90, 228, 0.807), rgba(98, 242, 100, 0.762));
+    background: linear-gradient(
+  135deg,
+  rgba(120, 100, 255, 0.95),  
+  rgba(255, 214, 204, 0.9),  
+  rgba(255, 251, 245, 0.96)  
+);
+
 
       color: var(--white);
       text-align: center;


### PR DESCRIPTION
## What's New?
## Description 

This PR improves the gradient background in the 'Graphic Design' section by updating the color blend to a lighter, more visually appealing combination of purplish-blue and soft peach tones. The new gradient offers a smoother, modern aesthetic that enhances the overall look and feel of the page.
## Related Issue:
Fixes : #380 
## Changes:

- Updated background gradient with a lighter purplish-blue and blush peach blend

- Improved opacity and color transitions for better contrast and readability

- Added subtle layering for depth and softness

## Benefits:

- Makes the section visually more attractive and engaging

- Maintains brand consistency with a fresh, contemporary design


## BEFORE
<img width="1832" height="615" alt="image" src="https://github.com/user-attachments/assets/31cdb939-e987-4766-b7b5-150e22c2b501" />


## AFTER
<img width="1819" height="739" alt="image" src="https://github.com/user-attachments/assets/9d43f0bd-e91e-4d80-818a-b574b420a209" />

Please merge this pull request.