### PR TITLE
Contact link fixed in services section

### DIFF
--- a/services.html
+++ b/services.html
@@ -410,7 +410,7 @@
                         <li><a href="./services.html">Services</a></li>
                         <li><a href="#">Portfolio</a></li>
                         <li><a href="#">Internship</a></li>
-                        <li><a href="#contact.html">Contact</a></li>
+                        <li><a href="./src/contact.html">Contact</a></li>
                     </ul>
                 </div>
 


### PR DESCRIPTION
Fixed the broken Contact link in the services.html footer section.
Added id="contact" to the footer contact block to enable proper anchor navigation.
Updated the link to correctly scroll to the contact section on the same page.
This improves user navigation and resolves the issue with the footer link.

I am a contributor from GSSOC'25
kindly check my  PR  for issue - #415  and merge it accordingly