### PR TITLE
Favicon added in Cyber Analyst Page

### DIFF
--- a/src/cyber-analyst.html
+++ b/src/cyber-analyst.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cyber Analyst </title>
+    <link rel="shortcut icon" href="../Favicon.ico" type="image/x-icon">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <link rel="shortcut icon" href="Favicon.ico" type="image/x-icon" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />


### PR DESCRIPTION
Added a favicon to the Cyber Analyst Page for better branding and tab visibility. Updated the page’s head section to include the favicon link. Verified the favicon appears correctly across major browsers after cache refresh.
I am attaching a screenshot after my correction:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/612d2c4c-30dc-476b-8969-f97f8c4946ce" />

I am a contributor fromGSSOC'25
kindly check my PR on issue #427 and merge it accordingly