### PR TITLE
Fix : Homepage cards redirect issue solved 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1193,7 +1193,7 @@
 
         <!-- Graphic Designing -->
         <div class="col-sm-12 col-md-6 col-lg-4">
-          <a href="#" class="training-links">
+          <a href="src/graphic_design.html" class="training-links">
             <div class="program-card d-flex align-items-center gap-2"
               data-tooltip="Create beautiful and professional designs.">
               <img src="images/icons/GraphicDesign.png" alt="Graphic Designing" class="icon" />
@@ -1204,7 +1204,7 @@
 
         <!-- Cyber Analyst - Now properly aligned -->
         <div class="col-sm-12 col-md-6 col-lg-4">
-          <a href="#" class="training-links">
+          <a href="src/cyber-analyst.html" class="training-links">
             <div class="program-card d-flex align-items-center gap-2" data-tooltip="A future safe from cyber threats.">
               <img src="images/icons/Cyb-security.png" alt="Cyber Analyst" class="icon" />
               <h6 class="mb-0">Cyber Analyst</h6>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #542 

## What changes are included in this PR?

<!--
Previously the cards named graphic design and cyber analyst were not redirecting user to their respective pages , which is now solved.

changed file - 
`index.html`
-->

## Are these changes tested?

<!--
Yes
-->


## Screenshots
 
Redirected pages - 

<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/74133c81-ad6f-43a1-9c89-a9e3b48a2a1d" />

the above page is redirected from graphic design card.

<img width="1897" height="910" alt="image" src="https://github.com/user-attachments/assets/a68b1ea8-e994-468d-b32a-bbbe297cd1de" />


the above page is redirected from cyber analyst card.
