### PR TITLE
Wrong link in Contact us page fixed

### DIFF
--- a/src/contact.html
+++ b/src/contact.html
@@ -439,8 +439,6 @@
       animation: slideUp 0.5s ease-out;
     }
 
-<<<<<<< HEAD
-=======
     /* Professional Footer */
     .professional-footer {
       background: linear-gradient(135deg, #1a202c 0%, #2d3748 100%);
@@ -575,7 +573,6 @@
     .footer-links a:hover::before {
       opacity: 1;
     }
->>>>>>> upstream/master
 
     .contact-info {
       position: relative;
@@ -675,7 +672,7 @@
             <a class="nav-link" href="../index.html#about">About Us</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="../index.html#work">Our Work</a>
+            <a class="nav-link" href="../work.html">Our Work</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="contact.html">Contact Us</a>


### PR DESCRIPTION

- Closes #604 

## Rationale for this change

The "Contact Us" page contained an incorrect link, which could mislead users and affect navigation.  
This fix ensures that the link correctly redirects users to the intended contact page.

## What changes are included in this PR?

- Updated the incorrect link in the "Contact Us" page to point to the correct destination.

## Are these changes tested?

- Yes, the fix has been tested locally by verifying navigation from the "Contact Us" menu and ensuring it redirects to the correct page.  

## Are there any user-facing changes?

- Yes, users will now be directed to the correct contact page when clicking on "Contact Us".  

i am a contributor from gssoc'25 and fixed this issue kindly check and merge my pr accordingly.
@gyanshankar1708 
