### PR TITLE
Corrected the extra broken image pic

### DIFF
--- a/blogWrite.html
+++ b/blogWrite.html
@@ -931,11 +931,6 @@
           <li class="nav-item"><a class="nav-link active" href="./index.html#about">About Us</a></li>
           <li class="nav-item"><a class="nav-link active" href="./index.html#work">Our Work</a></li>
           <li class="nav-item"><a class="nav-link active" href="src/contact.html">Contact Us</a></li>
-          <li class="nav-item">
-            <button class="btn btn-link nav-link" id="darkModeToggle" title="Toggle dark mode">
-              <img src="images/dark-mode-icon.png" alt="Dark Mode" width="24" height="24" id="darkModeIcon">
-            </button>
-          </li>
         </ul>
       </div>
       


### PR DESCRIPTION


- Closes #603 

## Rationale for this change

On the Blog Write page, an unintended extra/broken image icon appeared next to the **"Contact Us"** menu item.  
This broke the clean UI layout and could confuse users.  
The fix removes the unnecessary image reference to restore a consistent navigation experience.

## What changes are included in this PR?

- Removed the unintended/extra image icon from the "Contact Us" navigation item.  
- Ensured alignment and spacing remain consistent after removal.  

## Are these changes tested?

- Yes, tested locally to confirm the "Contact Us" menu item displays correctly without the extra icon.  

## Are there any user-facing changes?

- Yes, users will no longer see the broken/extra image icon next to "Contact Us".  
- The navigation bar looks cleaner and more professional.  

I ama Contributor from Gssoc'25... kindly check and merge my PR. @gyanshankar1708 