### PR TITLE
Card Hover Description Overlaps Page Heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -1563,7 +1563,7 @@
   <div class="bg-body-tertiary mt-4 py-2 mb-4 ">
     <div class="container-fluid d-flex flex-wrap justify-content-center align-items-center px-2 px-sm-5 mt-3 mb-4">
       <h5 class="head-training mb-xxl-0">Training and Internship program</h5>
-      <div class="row g-4 px-6 py-6 justify-content-md-center"  style="margin-top: 30px;">
+      <div class="row g-4 px-6 py-6 justify-content-md-center"  style="margin-top: 28px;">
 
         <!-- Website Development -->
         <div class="col-sm-12 col-md-6 col-lg-4">


### PR DESCRIPTION
## Which issue does this PR close?

When hovering on the Training and Internship Program cards (e.g., Digital Marketing), the description text overlapped with the section heading, making the UI look broken and unreadable. This PR resolves the spacing issue to ensure a cleaner and more professional layout.

- Closes #580  
## What changes are included in this PR?

- Added margin between the section heading and card container so that the hover description does not overlap with the heading.
- Ensured that the description remains neatly inside the card on hover.
- Verified responsiveness so spacing works well across devices.

## Are these changes tested?

- Yes, the changes have been manually tested on:

1. Desktop (large screens)
2. Tablet (medium screens)
3. Mobile (small screens)

- The layout remains consistent and the overlap issue is resolved.

## Are there any user-facing changes?

Yes.

- Users will now see proper spacing between the section heading and cards.
- The hover description stays confined to the card, avoiding overlap with other elements.
- Overall UI looks cleaner and easier to read.

## Screenshots
before
<img width="1838" height="621" alt="image" src="https://github.com/user-attachments/assets/b540332d-f923-4a3a-a53c-d54dab1b64fe" />
after
<img width="1915" height="902" alt="image" src="https://github.com/user-attachments/assets/f071fdad-798e-4066-b60d-5599e6ee4bdf" />

