### PR TITLE
fix: add theme toggle to Graphic Design & Content Writing pages 

### DIFF
--- a/learn/contentwriting.html
+++ b/learn/contentwriting.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -5,54 +6,77 @@
   <title>Content Writing Portfolio</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
   <style>
-  .card {
-  border: none;
-  border-radius: 16px;
-  overflow: hidden;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
+    :root {
+      --bg: #ffffff;
+      --fg: #0f172a;        /* text color light */
+      --card: #f8fafc;
+      --border: #e5e7eb;
+      --link: #0d6efd;
+    }
+    :root[data-theme="dark"] {
+      --bg: #0b1120;
+      --fg: #e2e8f0;        /* text color dark */
+      --card: #111827;
+      --border: #1f2937;
+      --link: #93c5fd;
+    }
 
-.card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.1);
-}
+    html, body { background: var(--bg); color: var(--fg); }
 
-.card-img-top {
-  height: 220px;
-  object-fit: cover;
-  border-bottom: 1px solid #eaeaea;
-}
+    /* back button + links */
+    a:not(.btn-link) { color: var(--link); }
+    a:not(.btn-link):hover { opacity: 0.9; }
+    .btn-link { color: var(--fg) !important; }
+    .btn-link:hover { text-decoration: underline; opacity: 0.9; }
 
-.card-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #2d2d2d;
-}
+    .card {
+      border: none;
+      border-radius: 16px;
+      overflow: hidden;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      background: var(--card);
+    }
+    .card:hover { transform: translateY(-5px); box-shadow: 0 12px 30px rgba(0,0,0,0.1); }
+    .card-img-top { height: 220px; object-fit: cover; border-bottom: 1px solid var(--border); }
 
-.card-text {
-  font-size: 0.95rem;
-  color: #555;
-}
+    h1, h2, h3, h4, h5, h6,
+    .card-title, .card-text, p { color: var(--fg); }
 
-h1 {
-  font-weight: 700;
-  color: #1f1f1f;
-}
+    h1 { font-weight: 700; }
+    .card-title { font-size: 1.25rem; font-weight: 600; }
+    .card-text { font-size: 0.95rem; }
+    section.container { padding-top: 3rem; padding-bottom: 3rem; }
 
-section.container {
-  padding-top: 3rem;
-  padding-bottom: 3rem;
-}
+    /* Big toggle button */
+    #themeToggle {
+      border: 0;
+      background: transparent;
+      cursor: pointer;
+      font-size: 2.2rem;
+      padding: 0.4rem 0.8rem;
+      border-radius: 8px;
+      transition: background 0.2s ease;
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      line-height: 1;
+    }
+    #themeToggle:hover { background: rgba(0,0,0,0.05); }
   </style>
 </head>
 <body>
+  <!-- Back link -->
   <div class="container mt-4">
     <a href="../index.html" class="btn btn-link text-decoration-none d-flex align-items-center" style="font-size: 1.1rem;">
       &#8592; <span class="ms-2">Back</span>
     </a>
   </div>
-  <!-- Navbar -->
-  <!-- ... Navbar code ... -->
+
+  <!-- Theme toggle button -->
+  <button id="themeToggle" aria-label="Toggle theme">
+    <span id="themeIcon">🌙</span>
+  </button>
+
   <section class="container mt-5">
     <h1 class="mb-4 text-center">Content Writing Samples</h1>
     <p class="text-center mb-5">Every word crafted to inform, inspire, and convert.</p>
@@ -86,5 +110,28 @@ section.container {
       </div>
     </div>
   </section>
+
+  <!-- Theme toggle script -->
+  <script>
+    (function() {
+      const root = document.documentElement;
+      const btn = document.getElementById('themeToggle');
+      const icon = document.getElementById('themeIcon');
+
+      function applyTheme(t) {
+        root.setAttribute('data-theme', t);
+        localStorage.setItem('theme', t);
+        icon.textContent = (t === 'dark') ? '☀️' : '🌙';
+      }
+
+      const saved = localStorage.getItem('theme') || 'light';
+      applyTheme(saved);
+
+      btn.addEventListener('click', () => {
+        const next = (root.getAttribute('data-theme') === 'dark') ? 'light' : 'dark';
+        applyTheme(next);
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #637  


## Rationale for this change

Both the Graphic Design and Content Writing pages were missing the theme toggle button and always defaulted to light mode.  
This PR adds the toggle button and ensures proper dark mode readability for text, links, and cards.

## What changes are included in this PR?

- Added a theme toggle button (top-right) to both pages
- Implemented dark mode with CSS variables
- Improved text, link, and card colors for contrast
- Toggle state is saved in `localStorage` and persists after reload

## Are these changes tested?

Yes ✅  
- Verified toggle works on both pages locally  
- Tested theme persistence across reloads  
- Checked text/link readability in dark mode  

## Are there any user-facing changes?

Yes.  
- Users can now switch between light and dark themes on the Graphic Design and Content Writing pages.  
- Improved accessibility in dark mode.

## Screenshots

### before
<img width="1918" height="955" alt="image" src="https://github.com/user-attachments/assets/fa0c156d-9706-4455-930e-7f9a1758644d" />

### after 
<img width="1918" height="967" alt="image" src="https://github.com/user-attachments/assets/23e95a8f-1d89-40fa-8373-d3e3ef1c5964" />
