### PR TITLE
Fix: Center Read More button and style Explore link as button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1799,8 +1799,11 @@
                 team specializes in SEO, PPC, social media, email campaigns, and content marketing.
               </p>
               <div class="btn-group">
-                <button class="btn btn-sm btn-outline-primary toggle-btn rounded" onclick="event.stopPropagation();">Read More</button>
-                <a href="src/digital-marketing.html" onclick="event.stopPropagation();"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
+<button class="btn btn-sm btn-outline-primary toggle-btn rounded "
+  onclick="event.stopPropagation();" style="display:block; margin:0 auto;">
+  Read More
+</button>
+                <a href="src/digital-marketing.html" onclick="event.stopPropagation();" style="text-decoration: none;"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
               </div>
             </div>
           </div>
@@ -1827,8 +1830,11 @@
                 and performance-optimized websites aligned with your goals.
               </p>
               <div class="btn-group">
-                <button class="btn btn-sm btn-outline-primary toggle-btn rounded">Read More</button>
-                <a href="src/web.html"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
+<button class="btn btn-sm btn-outline-primary toggle-btn rounded"
+  onclick="event.stopPropagation();" style="display:block; margin:0 auto;">
+  Read More
+</button>
+                <a href="src/web.html"  style="text-decoration: none;"><button class="btn btn-sm btn-outline-primary" >Explore</button></a>
               </div>
             </div>
           </div>
@@ -1857,8 +1863,11 @@
                 leave a lasting impression.
               </p>
               <div class="btn-group">
-                <button class="btn btn-sm btn-outline-primary toggle-btn rounded">Read More</button>
-                <a href="#"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
+<button class="btn btn-sm btn-outline-primary toggle-btn rounded"
+  onclick="event.stopPropagation();" style="display:block; margin:0 auto;">
+  Read More
+</button>
+                <a href="#"  style="text-decoration: none;"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
               </div>
             </div>
           </div>
@@ -1887,8 +1896,11 @@
                 and brand loyalty.
               </p>
               <div class="btn-group">
-                <button class="btn btn-sm btn-outline-primary toggle-btn rounded">Read More</button>
-                <a href="#"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
+<button class="btn btn-sm btn-outline-primary toggle-btn rounded"
+  onclick="event.stopPropagation();" style="display:block; margin:0 auto;">
+  Read More
+</button>
+                <a href="#"  style="text-decoration: none;"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
               </div>
             </div>
           </div>
@@ -1916,8 +1928,11 @@
                 results and builds your brand voice.
               </p>
               <div class="btn-group">
-                <button class="btn btn-sm btn-outline-primary toggle-btn rounded">Read More</button>
-                <a href="learn/contentwriting.html"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
+<button class="btn btn-sm btn-outline-primary toggle-btn rounded"
+  onclick="event.stopPropagation();" style="display:block; margin:0 auto;">
+  Read More
+</button>
+                <a href="learn/contentwriting.html"  style="text-decoration: none;"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
               </div>
             </div>
           </div>
@@ -1946,8 +1961,11 @@
                 future-proof society
               </p>
               <div class="btn-group">
-                <button class="btn btn-sm btn-outline-primary toggle-btn rounded">Read More</button>
-                <a href="learn/cyberanalyst.html"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
+                <button class="btn btn-sm btn-outline-primary toggle-btn rounded"
+                    onclick="event.stopPropagation();" style="display:block; margin:0 auto;">
+                                            Read More</button>
+
+                <a href="learn/cyberanalyst.html"  style="text-decoration: none;"><button class="btn btn-sm btn-outline-primary">Explore</button></a>
               </div>
 
             </div>

--- a/index.html
+++ b/index.html
@@ -1563,7 +1563,7 @@
   <div class="bg-body-tertiary mt-4 py-2 mb-4 ">
     <div class="container-fluid d-flex flex-wrap justify-content-center align-items-center px-2 px-sm-5 mt-3 mb-4">
       <h5 class="head-training mb-xxl-0">Training and Internship program</h5>
-      <div class="row g-4 px-6 py-6 justify-content-md-center"  style="margin-top: 30px;">
+      <div class="row g-4 px-6 py-6 justify-content-md-center"  style="margin-top: 28px;">
 
         <!-- Website Development -->
         <div class="col-sm-12 col-md-6 col-lg-4">

--- a/index.html
+++ b/index.html
@@ -1563,7 +1563,7 @@
   <div class="bg-body-tertiary mt-4 py-2 mb-4 ">
     <div class="container-fluid d-flex flex-wrap justify-content-center align-items-center px-2 px-sm-5 mt-3 mb-4">
       <h5 class="head-training mb-xxl-0">Training and Internship program</h5>
-      <div class="row g-4 px-6 py-6 justify-content-md-center"  style="margin-top: 40px;">
+      <div class="row g-4 px-6 py-6 justify-content-md-center"  style="margin-top: 30px;">
 
         <!-- Website Development -->
         <div class="col-sm-12 col-md-6 col-lg-4">

--- a/index.html
+++ b/index.html
@@ -1563,7 +1563,7 @@
   <div class="bg-body-tertiary mt-4 py-2 mb-4 ">
     <div class="container-fluid d-flex flex-wrap justify-content-center align-items-center px-2 px-sm-5 mt-3 mb-4">
       <h5 class="head-training mb-xxl-0">Training and Internship program</h5>
-      <div class="row g-4 px-6 py-6 justify-content-md-center">
+      <div class="row g-4 px-6 py-6 justify-content-md-center"  style="margin-top: 40px;">
 
         <!-- Website Development -->
         <div class="col-sm-12 col-md-6 col-lg-4">


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #578 

## Rationale for this change

- The Read More button had excess spacing on the right side, which made the design look unbalanced.

- The Explore link was showing as a default blue underlined hyperlink, instead of a styled button.

This change ensures both buttons are aligned, clean, and consistent in appearance.

## What changes are included in this PR?

- Adjusted margin/padding for the Read More button so it appears centered and balanced.

- Removed underline and default hyperlink style from the Explore link.

- Styled the Explore link as a button so it matches the design of the Read More button.

## Are these changes tested?

Yes, changes were manually tested in the UI to confirm that:

- The Read More button is centered with no extra spacing.

- The Explore link appears as a button without underline.

## Are there any user-facing changes?

Yes. Users will now see:

- A neatly centered Read More button.

- An Explore button that is visually consistent with the Read More button (no underline or blue hyperlink).

## Screenshots

before
<img width="1907" height="909" alt="image" src="https://github.com/user-attachments/assets/9bce7beb-03c4-4a78-a2fb-12cf36a7f199" />

After 
<img width="1907" height="909" alt="image" src="https://github.com/user-attachments/assets/9bce7beb-03c4-4a78-a2fb-12cf36a7f199" />


