### PR TITLE
[BUG FIX] fixed the footer links on webdevelopment page

### DIFF
--- a/src/web.html
+++ b/src/web.html
@@ -1799,18 +1799,19 @@
           </div>
         </div>
 
-        <!-- Services Links -->
-        <div class="col-lg-2 col-md-3 col-6 fade-in">
-          <h5 class="footer-title">Services</h5>
-          <ul class="footer-links">
-            <li><a href="learn/webdev.html">Web Development</a></li>
-            <li><a href="learn/graphic.html">Graphic Design</a></li>
-            <li><a href="learn/marketing.html">Digital Marketing</a></li>
-            <li><a href="learn/contentwriting.html">Content Writing</a></li>
-            <li><a href="learn/socialmedia.html">Social Media</a></li>
-            <li><a href="learn/cyberanalyst.html">Cyber Analyst</a></li>
-          </ul>
-        </div>
+       <!-- Services Links -->
+<div class="col-lg-2 col-md-3 col-6 fade-in">
+  <h5 class="footer-title">Services</h5>
+  <ul class="footer-links">
+    <li><a href="../learn/webdev.html">Web Development</a></li>
+    <li><a href="../learn/graphic.html">Graphic Design</a></li>
+    <li><a href="../learn/marketing.html">Digital Marketing</a></li>
+    <li><a href="../learn/contentwriting.html">Content Writing</a></li>
+    <li><a href="../learn/socialmedia.html">Social Media</a></li>
+    <li><a href="../learn/cyberanalyst.html">Cyber Analyst</a></li>
+  </ul>
+</div>
+
 
         <!-- Quick Links -->
         <div class="col-lg-2 col-md-3 col-6 fade-in">


### PR DESCRIPTION
Description:
Currently, the footer service links in web.html were using paths like learn/webdev.html. Since the learn folder is located outside the src folder, these links were broken and caused Cannot GET /src/learn/webdev.html errors.
This PR updates all service links in the footer to use ../learn/... paths, which correctly navigate one folder up from src to the learn folder.
Impact:
Fixes broken links in the footer of web.html.
Improves user experience by allowing navigation to all service pages.
Prevents 404 errors when accessing service pages.

This is a simple path correction; no styling or content changes were made.
All relative links use ../learn/... to account for web.html being in src/ and learn/ being outside src/.

https://github.com/user-attachments/assets/e0aaae96-4f6c-4f99-a17d-9a2337915bc2

