### PR TITLE
Fix Contact Button Link on FAQ Page

### DIFF
--- a/src/faq.html
+++ b/src/faq.html
@@ -962,7 +962,7 @@
           <div class="faq-cta text-center mt-5">
             <h3>Still have questions?</h3>
             <p>Can't find what you're looking for? Our team is here to help!</p>
-            <a href="src/contact.html" class="btn btn-primary btn-lg">
+            <a href="../src/contact.html" class="btn btn-primary btn-lg">
               <i class="fas fa-envelope"></i> Contact Us
             </a>
           </div>


### PR DESCRIPTION
**Description:**
On the faq.html page:

- The “Contact” button is not linked to the Contact Us page.
- Users cannot directly navigate to the contact form from FAQ.
- This affects usability and user flow.

closed issue #734 

**Expected Behavior:**

- Clicking the Contact button should take the user to the Contact Us page.
- Link should be tested to ensure it works on all devices.

Screenshot:
Before
<img width="1897" height="776" alt="image" src="https://github.com/user-attachments/assets/b295f882-3da9-442d-b235-5825a9a797d6" />
after
<img width="1907" height="740" alt="image" src="https://github.com/user-attachments/assets/679418de-377f-4629-9761-f4258ebd2227" />
