### PR TITLE
Fix 'Services' navigation link and update logo to black

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -747,7 +747,7 @@
   <nav class="navbar navbar-expand-lg bg-body-tertiary">
     <div class="container-fluid d-flex justify-content-between align-items-center px-2 px-sm-5">
       <a class="navbar-brand" href="index.html">
-        <img src="images/Logo.png" alt="GrowCraft" width="200" id="logo" />
+        <img src="images/Logo_new.png" alt="GrowCraft" width="200" id="logo" />
       </a>
 
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
@@ -761,7 +761,7 @@
             <a class="nav-link" aria-current="page" href="index.html">Home</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" aria-current="page" href="services.html">Services</a>
+            <a class="nav-link" aria-current="page" href="index.html#services">Services</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" aria-current="page" href="blogListing.html">Blogs</a>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #818 

## Rationale for this change

The **'Services'** link was not working properly in the navigation.  
Also, the previous **white logo** did not fit well with the design, so it was replaced with a **black logo** for better visibility and consistency.  

## What changes are included in this PR?

- Fixed the **'Services'** navigation link so it now redirects correctly.  
- Replaced the **white logo** with a **black logo**.  

(‘Our Work’ link issue was already fixed earlier by someone else, so not included in this PR.)  

## Are these changes tested?

- Yes, tested locally.  
- Verified that **Services** link redirects correctly.  
- Confirmed that the **black logo** is displayed properly across all pages.  

## Are there any user-facing changes?

- Yes.  
  - Users will now see the **black logo** instead of the white logo.  
  - The **Services** link in the navbar works correctly.  

## Screenshots

after
<img width="1919" height="115" alt="image" src="https://github.com/user-attachments/assets/5411c0df-2340-4cd4-81fb-935f962d78e6" />

