### PR TITLE
Added dark mode in webdev.html

### DIFF
--- a/learn/webdev.html
+++ b/learn/webdev.html
@@ -59,19 +59,13 @@
             <input type="text" placeholder="Search..." />
           </div>
           <i class="fa-solid fa-magnifying-glass"></i>
+          <div class="theme-toggle-wrapper ms-3">
+            <div class="theme-toggle-btn" id="themeToggle">
+              <i class="fas fa-moon"></i>
+            </div>
+          </div>
         </div>
-        <!-- Toggler -->
-        <button
-          class="navbar-toggler"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#navbarNav"
-          aria-controls="navbarNav"
-          aria-expanded="false"
-          aria-label="Toggle navigation"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
+        
       </div>
     </nav>
     <!-- Navbar ends here -->
@@ -516,6 +510,54 @@
           navbar.classList.remove("scrolled");
         }
       });
+
+      // Enhanced Dark Mode Toggle Functionality
+document.addEventListener('DOMContentLoaded', function() {
+  const themeToggle = document.getElementById('themeToggle');
+  const themeIcon = themeToggle.querySelector('i');
+  
+  // Check for saved theme preference
+  const savedTheme = localStorage.getItem('theme') || 'light';
+  
+  // Apply saved theme
+  if (savedTheme === 'dark') {
+    document.body.classList.add('dark-mode');
+    themeIcon.classList.remove('fa-moon');
+    themeIcon.classList.add('fa-sun');
+  }
+  
+  // Toggle theme on button click
+  themeToggle.addEventListener('click', function() {
+    // Add click animation
+    this.style.transform = 'scale(0.9) rotate(-15deg)';
+    setTimeout(() => {
+      this.style.transform = '';
+    }, 300);
+    
+    document.body.classList.toggle('dark-mode');
+    
+    if (document.body.classList.contains('dark-mode')) {
+      themeIcon.classList.remove('fa-moon');
+      themeIcon.classList.add('fa-sun');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      themeIcon.classList.remove('fa-sun');
+      themeIcon.classList.add('fa-moon');
+      localStorage.setItem('theme', 'light');
+    }
+  });
+
+  // Add scroll effect for navbar
+  window.addEventListener('scroll', function() {
+    const navbar = document.querySelector('.navbar');
+    if (window.scrollY > 50) {
+      navbar.classList.add('scrolled');
+    } else {
+      navbar.classList.remove('scrolled');
+    }
+  });
+});
     </script>
+    
   </body>
 </html>

--- a/src/css/webdev.css
+++ b/src/css/webdev.css
@@ -576,3 +576,226 @@ h1 {
     text-align: left;
   }
 }
+/* Custom Dark Mode Toggle Styles */
+.theme-toggle-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.theme-toggle-btn {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  box-shadow: 0 4px 15px var(--shadow-color);
+  position: relative;
+  overflow: hidden;
+}
+
+.theme-toggle-btn::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, var(--accent-color), transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.theme-toggle-btn:hover {
+  transform: scale(1.1) rotate(15deg);
+  box-shadow: 0 6px 20px var(--shadow-color);
+}
+
+.theme-toggle-btn:hover::before {
+  opacity: 0.1;
+}
+
+.theme-toggle-btn:hover i {
+  color: var(--accent-color);
+  transform: scale(1.1);
+}
+
+.theme-toggle-btn i {
+  font-size: 1.3rem;
+  color: var(--text-primary);
+  transition: all 0.3s ease;
+  z-index: 2;
+}
+
+/* Dark Mode Global Styles */
+body.dark-mode {
+  background-color: #1a1a1a;
+  color: #e0e0e0;
+  transition: all 0.4s ease;
+}
+
+/* Dark Mode Navbar */
+body.dark-mode .navbar {
+  background: rgba(30, 30, 30, 0.95) !important;
+  backdrop-filter: blur(15px);
+  border-bottom: 1px solid #333;
+}
+
+body.dark-mode .nav-link {
+  color: #e0e0e0 !important;
+}
+
+body.dark-mode .nav-link:hover {
+  color: #4caf50 !important;
+  transform: translateY(-2px);
+}
+
+body.dark-mode .search-box input {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #555;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+body.dark-mode .navbar-toggler {
+  background-color: #333;
+  border: 1px solid #444;
+}
+
+body.dark-mode .navbar-toggler-icon {
+  filter: invert(0.8);
+}
+
+
+
+/* Dark Mode Cards */
+body.dark-mode .card {
+  background-color: #2d2d2d;
+  border: 1px solid #404040;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3) !important;
+}
+
+body.dark-mode .card:hover {
+  box-shadow: 0 15px 35px rgba(76, 175, 80, 0.2) !important;
+  transform: translateY(-8px) scale(1.02);
+}
+
+body.dark-mode .card-title {
+  color: #ffffff;
+}
+
+body.dark-mode .card-text {
+  color: #b0b0b0;
+}
+
+body.dark-mode .card-img-top {
+  border-bottom: 1px solid #f8f3f3;
+}
+
+/* Dark Mode Text Colors */
+body.dark-mode .web-title,
+body.dark-mode .section-title {
+  background: linear-gradient(45deg, #4caf50, #05df5f, #80e27e);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+body.dark-mode .sub-title {
+  color: #b0b0b0;
+}
+
+body.dark-mode h1 {
+  color: #ffffff;
+}
+
+/* Dark Mode Tech Stack */
+body.dark-mode .hover-effect {
+  background-color: #2d2d2d;
+  border: 1px solid #404040;
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.4) !important;
+}
+
+body.dark-mode .hover-effect:hover {
+  box-shadow: 0 8px 25px rgba(76, 175, 80, 0.2) !important;
+  transform: scale(1.05);
+}
+
+/* Dark Mode Testimonials */
+body.dark-mode .bg-light {
+  background-color: #1a1a1a !important;
+}
+
+body.dark-mode .client-container .card {
+  background-color: #2d2d2d;
+  border: 1px solid #404040;
+}
+
+body.dark-mode .text-muted {
+  color: #a0a0a0 !important;
+}
+
+/* Dark Mode Button */
+body.dark-mode .btn-success {
+  background: linear-gradient(135deg, #4caf50, #45a049);
+  border: none;
+  box-shadow: 0 4px 15px rgba(76, 175, 80, 0.3);
+}
+
+body.dark-mode .btn-success:hover {
+  background: linear-gradient(135deg, #45a049, #4caf50);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(76, 175, 80, 0.4);
+}
+
+/* Dark Mode Footer */
+body.dark-mode .professional-footer {
+  background-color: #1a1a1a !important;
+  color: #e0e0e0 !important;
+  border-top: 1px solid #333 !important;
+}
+
+body.dark-mode .footer-title {
+  color: #ffffff !important;
+}
+
+body.dark-mode .brand-description,
+body.dark-mode .footer-links a,
+body.dark-mode .contact-item a,
+body.dark-mode .contact-item span,
+body.dark-mode .copyright,
+body.dark-mode .footer-nav a {
+  color: #b0b0b0 !important;
+}
+
+body.dark-mode .footer-links a:hover,
+body.dark-mode .contact-item a:hover,
+body.dark-mode .footer-nav a:hover {
+  color: #4caf50 !important;
+  transform: translateX(5px);
+}
+
+body.dark-mode .footer-bottom {
+  background: rgba(0, 0, 0, 0.4) !important;
+  border-top: 1px solid #333 !important;
+}
+
+/* Smooth transitions for all elements */
+.navbar, .card, .hover-effect, .btn, .professional-footer,
+.nav-link, .search-box input, .web-title, .sub-title {
+  transition: all 0.4s ease;
+}
+
+/* Container background fix */
+body.dark-mode .container {
+  background-color: transparent;
+}
+
+/* Stack container dark mode */
+body.dark-mode .stack-container {
+  background: transparent;
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #834 

## Rationale for this change

The webdev.html page did not support dark mode, unlike other pages that adapt correctly when the dark mode toggle is used. Additionally, this page lacked a toggle button, leading to inconsistency in user experience and accessibility.

## What changes are included in this PR?

- Added dark mode support to webdev.html.
- Implemented the dark mode toggle button for consistency across all pages.
- Updated styles to ensure proper readability and accessibility in both modes.

## Are these changes tested?

- Manually tested light and dark mode toggling.
- Verified consistency with other pages.

## Are there any user-facing changes?

Yes. Users can now toggle dark mode on webdev.html, achieving a consistent experience across the website.

## Screenshot

<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/bfea5a31-baaa-402a-9aa1-df48781961d5" />

