### PR TITLE
[BUG FIX] Portfolio page is directed properly in footer section in di…

### DIFF
--- a/src/digital-marketing.html
+++ b/src/digital-marketing.html
@@ -1468,7 +1468,7 @@
                     <ul class="list-unstyled">
                         <li><a href="../index.html" class="text-decoration-none">Home</a></li>
                         <li><a href="../index.html#services" class="text-decoration-none">Services</a></li>
-                        <li><a href="../src/workList.html" class="text-decoration-none">Portfolio</a></li>
+                        <li><a href="../learn/webdev.html" class="text-decoration-none">Portfolio</a></li>
                         <li><a href="../index.html#internship" class="text-decoration-none">Internship</a></li>
                         <li><a href="../src/contact.html" class="text-decoration-none">Contact</a></li>
                     </ul>


### PR DESCRIPTION
Closes #642 

Rationale for this change

The portfolio link on the Digital Marketing page was not redirecting properly. This could lead to poor user experience and broken navigation flow. The fix ensures users can access the portfolio section without errors.

What changes are included in this PR?

Fixed the portfolio link redirection on the Digital Marketing page.

Updated anchor tag/URL routing to point to the correct destination.

Verified that the link works consistently across different devices and screen sizes.

Are these changes tested?

 Manually tested the portfolio link on the Digital Marketing page.

Verified navigation works correctly in both desktop and mobile view.

No automated tests were added since this is a front-end redirection fix.

Are there any user-facing changes?

Yes. Users can now properly access the Portfolio section from the Digital Marketing page without facing broken or incorrect links.


https://github.com/user-attachments/assets/007c93e6-708d-4d6e-8489-d492fa9dd8b8


