### PR TITLE
Fix: broken Custom Web Apps icon in Web Development page slider (#915)

### DIFF
--- a/src/web.html
+++ b/src/web.html
@@ -1632,7 +1632,7 @@
           <p>Personalized spaces to showcase your skills and work.</p>
         </div>
         <div class="glass-item" role="option" aria-label="Custom Web Apps">
-          <img src="https://cdn-icons-png.flaticon.com/512/108/10838348.png" alt="Web App Icon" />
+          <img src="https://image.pngaaa.com/346/2431346-middle.png" alt="Web App Icon" />
           <h3>Custom Web Apps</h3>
           <p>Tailor-made applications for startups, businesses, and teams.</p>
         </div>


### PR DESCRIPTION
**Description**
Fixed the broken “Custom Web Apps” icon image in the slider section of the Web Development page. The image was either mis-referenced or missing, causing it to render as a broken icon and degrading the page’s visual quality.

**Steps to Reproduce**
1. Open the Web Development page.
2. Scroll to the slider section showcasing different services.
3. Notice that the “Custom Web Apps” icon image appears as a blank/broken image.

**Expected Behavior**
The “Custom Web Apps” slide should display its icon image consistently with the other slides.

**Actual Behavior**
The “Custom Web Apps” icon image was missing or broken.

**Type of Issue**
- [x] Bug  
- [ ] Enhancement  
- [ ] UI/UX Issue  

**Fix Implemented**
Corrected the image path/reference for the “Custom Web Apps” icon in the slider component so it now loads properly across all browsers and modes.

**Environment**
Page: Web Development  
Section: Slider (Services Showcase)  
Browser: All  
Mode: Both Light and Dark  

Contributor: Hacktoberfest’25
