### PR TITLE
Fix: add missing text 'Explore' to Content Writing button (#917)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@ body {
 
               <div class="btn-group mt-3 d-flex gap-2">
                 <button class="toggle-btn">Read More</button>
-                <a href="learn/contentwriting.html" class="btn btn-sm btn-outline-primary hover-scale rounded "></a>
+                <a href="learn/contentwriting.html" class="btn btn-sm btn-outline-primary hover-scale rounded ">Explore</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
**Description**
Fixed the missing text issue for the “Explore” button on the Content Writing card in the Services section of the Home page. Previously, the button rendered blank, causing a UI inconsistency.

**Steps to Reproduce**
1. Open the Home page.
2. Scroll to the Services section.
3. Locate the Content Writing card.
4. Observe that the “Explore” button is blank while “Read More” displays correctly.

**Expected Behavior**
Both buttons on the Content Writing card should display their text labels correctly. The second button should show “Explore”.

**Actual Behavior**
The “Explore” button was missing its text and appeared blank.

**Type of Issue**
- [x] Bug  
- [ ] Enhancement  
- [ ] UI/UX Improvement  

**Fix Implemented**
Added the missing text label “Explore” to the button element in the card template, ensuring proper display and consistency with other buttons in the Services section.

**Environment**
Page: Home  
Section: Services → Content Writing card  
Browser: All  
Mode: Both Light and Dark  

Contributor: Hacktoberfest’25
