### PR TITLE
Growcraft logo in terms page adjusted brightness accordingly

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1246,6 +1246,10 @@ body.dark .mb-4:hover {
   object-fit: contain;
   vertical-align: middle;
 }
+/* Dark mode logo fix */
+[data-bs-theme="dark"] .navbar-brand img {
+  filter: brightness(0) invert(1);
+}
 
 /* Align all nav items vertically center */
 .navbar-nav .nav-link {

--- a/terms.html
+++ b/terms.html
@@ -767,7 +767,7 @@
   <nav class="navbar navbar-expand-lg bg-body-tertiary">
     <div class="container-fluid d-flex justify-content-between align-items-center px-2 px-sm-5">
       <a class="navbar-brand" href="index.html">
-        <img src="images/Logo.png" alt="GrowCraft" width="200" id="logo" />
+        <img src="images/logo_bg_transparent.png" alt="GrowCraft" width="200" id="logo" />
       </a>
 
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"


### PR DESCRIPTION

- Closes #933 

fixed this issue where growcraft logo was not visible in light mode... adjusted my changing theme based picture in light mode and added  a new block for dark mode to ensure smooth visibility in both modes. plz check and merge @gyanshankar1708 
