### PR TITLE
footers links corrected in graphic designing page

### DIFF
--- a/src/graphic_design.html
+++ b/src/graphic_design.html
@@ -1797,9 +1797,9 @@
           </div>
           <div class="col-md-6">
             <div class="footer-nav">
-              <a href="#privacy">Privacy</a>
-              <a href="#terms">Terms</a>
-              <a href="#sitemap">Sitemap</a>
+              <a href="../privacy.html">Privacy</a>
+              <a href="../terms.html">Terms</a>
+              <a href="../sitemap.html">Sitemap</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION


- Closes #961

privacy , terms , and sitemap buttons were not working in footer section of digital marketing page.. fixed broken links. plz check and merge. @gyanshankar1708 
