### PR TITLE
extra request consultation button removed from cyber analyst page

### DIFF
--- a/src/cyber-analyst.html
+++ b/src/cyber-analyst.html
@@ -1495,7 +1495,7 @@ textarea { min-height:84px; resize:vertical; }
   </aside>
 
   <!-- Sticky CTA -->
-  <button id="gc-sticky-cta" class="gc-sticky-cta" aria-label="Request a consultation">Request Consultation</button>
+  
 </section>
 <!-- ===== GrowCraft: Why Cybersecurity Matters (Interactive Section) ===== -->
 <section id="gc-why-cyber" class="gc-why-cyber" aria-labelledby="gc-why-title">


### PR DESCRIPTION

- Closes #965

There was an extra request consultation button covering privacy , terms and sitemap i couldn't find the code where the button was added while solving so i had to research a bit and use devtools to find at last ... i have now removed it from the footer of cyber analyst page... so, if possible plz give level 2. @gyanshankar1708 