### PR TITLE
[BUG FIX] Footer link directing to respective pages in portfolio page.

### DIFF
--- a/learn/webdev.html
+++ b/learn/webdev.html
@@ -411,7 +411,7 @@
                 >
               </li>
               <li>
-                <a href="contentwriting.html"
+                <a href="contentWriting.html"
                   ><i class="fas fa-pen-nib"></i> Content Writing</a
                 >
               </li>


### PR DESCRIPTION
#641 
Description:
This pull request resolves the issue where the footer links on the Portfolio page were not navigating to their intended destinations.

Changes Made:
Corrected incorrect href attributes for footer links.
Ensured all external links open in a new tab using target="_blank" and rel="noopener noreferrer".
Verified that internal navigation works smoothly using relative paths.
Cleaned up redundant or broken links in the footer section.

How to Test:
Navigate to the Portfolio page in the app/website.
Scroll down to the footer section.
Click on each link and confirm:
Internal links (e.g., Home, About, Contact) open the correct internal pages.
Verify there are no console errors or broken redirects.

https://github.com/user-attachments/assets/d708eff3-679e-40f2-8c82-1e89ec99e015


