### PR TITLE
extra css text removed from footer of contactus page

### DIFF
--- a/src/contact.html
+++ b/src/contact.html
@@ -997,8 +997,7 @@ if (typeof intlTelInput !== 'undefined') {
   </script>
   <script src="darkMode.js"></script>
 
-
- // Back to Top Button (GrowCraft)
+ 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   let backToTopBtn = document.getElementById('backToTop');


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #1215 

unnecessary css text was present in footer section of contact us page . i have fixed that . plz check and merge @gyanshankar1708 